### PR TITLE
DEV-028-SCS: Fixes in 'Simulator' and 'Logger' classes

### DIFF
--- a/project1/src/external_arrival_generator.py
+++ b/project1/src/external_arrival_generator.py
@@ -48,7 +48,7 @@ class ExternalArrivalGenerator:
         return Event(
             time=now + arrival_time,
             type=EventTypes.WORKER_RECEIVE_EXT_MSG,
-            message=Message(WORKER_COMPUTER, now),
+            message=Message(WORKER_COMPUTER, now + arrival_time),
             target=WORKER_COMPUTER,
         )
 
@@ -88,6 +88,6 @@ class ExternalArrivalGenerator:
         return Event(
             time=now + arrival_time,
             type=EventTypes.LAZY_RECEIVE_EXT_MSG,
-            message=Message(LAZY_COMPUTER, now),
+            message=Message(LAZY_COMPUTER, now + arrival_time),
             target=LAZY_COMPUTER,
         )

--- a/project1/src/logger.py
+++ b/project1/src/logger.py
@@ -16,6 +16,7 @@ class Logger:
         lazy_computer: Computer,
         sim_number: int,
         speed: SpeedMode = SpeedMode.SILENT,
+        joint_work_time = float
     ) -> None:
         """
         Displays the current state of the system during a simulation event.
@@ -61,8 +62,8 @@ class Logger:
         print(f"Messages received by Lazy (C3): {lazy_computer.received_messages}")
         print(f"Messages rejected by Lazy (C3): {lazy_computer.rejected_messages}")
         print(
-            f"Total processing time (C1 + C2 + C3): "
-            f"{master_computer.busy_time + worker_computer.busy_time + lazy_computer.busy_time:.2f} s"
+            f"Current joint work time (C1, C2, C3): "
+            f"{joint_work_time:.2f} s"
         )
 
         time.sleep(speed.delay)

--- a/project1/src/simulator.py
+++ b/project1/src/simulator.py
@@ -87,6 +87,7 @@ class Simulator:
         self.total_runs = 0  # number of completed runs
         self.clock = 0.0  # current simulation timestamp
         self.joint_work_start_time = -1.0  # timestamp for start time of joint work
+        self.joint_work_time = 0.0  # counter for joint work time
 
         self.event_queue = []  # min-heap of pending events
         self.computers = []  # computer entities indexed by ID
@@ -117,6 +118,7 @@ class Simulator:
         self.computers.clear()  # reset computer container
         self.stats_collector.clear_iteration_records()  # clear stats for new run
         self.joint_work_start_time = -1
+        self.joint_work_time = 0.0
 
         # fresh computer instances for this run
         self.master_computer = MasterComputer()
@@ -362,6 +364,7 @@ class Simulator:
             lazy_computer=self.lazy_computer,
             sim_number=self.total_runs,
             speed=self.speed_mode,
+            joint_work_time=self.joint_work_time
         )
 
         # Verification to mark end of simulations
@@ -526,9 +529,11 @@ class Simulator:
         next_event = target.determine_message_outcome(self.clock, event.message)
 
         # If the 3 computers were working together, update the joint work time
+        # The time is updated locally and in the stats collector
         if self.joint_work_start_time != -1:
-            joint_work_time = self.clock - self.joint_work_start_time
-            self.stats_collector.add_joint_work_time(joint_work_time)
+            addend_joint_work = (self.clock - self.joint_work_start_time)
+            self.joint_work_time += addend_joint_work
+            self.stats_collector.add_joint_work_time(addend_joint_work)
             self.joint_work_start_time = -1
 
         # Store processed message in stats collector if it will be sent by the master

--- a/project1/src/simulator.py
+++ b/project1/src/simulator.py
@@ -11,6 +11,7 @@ from stats_collector import StatsCollector
 from external_arrival_generator import ExternalArrivalGenerator
 
 import heapq
+import time
 from typing import List, Tuple
 
 """
@@ -288,15 +289,30 @@ class Simulator:
         Each run resets simulation state, processes events until the queue empties,
         shows stats for the current run, and then advances to the next run.
         """
-
+        # Register data of the current simulation in "durations.txt"
+        with open("durations.txt", "a") as f:
+            f.write(f"SIMULATOR DATA: {self.max_time}s - {self.max_runs} runs\n")
+    
+        total_duration = 0.0  # counter for the total duration of the simulator
         while self.total_runs < self.max_runs:
 
             # Reset per-run simulation state
             self.initialize_sim()
 
             # Process events in chronological order
+            # Register time for each run of the simulation
+            start_sim_time = time.time()
             while self.event_queue:
                 self.process_next_event()
+            end_sim_time = time.time()
+
+            # Save duration for the current run and add it to the total time
+            duration = end_sim_time - start_sim_time
+            total_duration += duration
+
+            # Write duration of the current run in file "durations.txt"
+            with open("durations.txt", "a") as f:
+                f.write(f"Iteration: {self.total_runs + 1} - {duration:.4f}s\n")
 
             # Get stats for the iteration and show them
             self.stats_collector.record_iteration_statistics(
@@ -308,6 +324,13 @@ class Simulator:
 
             # Mark run as completed
             self.total_runs += 1
+
+        # Write the total duration of the simulations in file "durations.txt"
+        with open("durations.txt", "a") as f:
+            f.write(f"Total duration: {total_duration:.4f}s\n")
+            f.write(f"=" * 30)
+            f.write(f"\n")
+
 
         # Show a summary for the final statistics
         while True:

--- a/project1/src/simulator.py
+++ b/project1/src/simulator.py
@@ -543,3 +543,13 @@ class Simulator:
 
         # Schedule resulting follow-up event
         self.schedule_event(next_event)
+
+        # Computer that ended processing keeps working if its queue is not empty
+        if target.get_enqueued_messages() > 0:
+            self.schedule_event(
+                Event(
+                    self.clock,
+                    type=target.get_start_processing_event_type(),
+                    target=event.target,
+                )
+            )

--- a/project1/src/simulator.py
+++ b/project1/src/simulator.py
@@ -201,7 +201,7 @@ class Simulator:
         print("\nEFFICIENCY COEFFICIENTS")
         print("-" * 50)
         for i in range(len(avg_wait)):
-            print(f"- {message_titles[i]}: {eff[i]:.4f}s")
+            print(f"- {message_titles[i]}: {eff[i]:.4f}")
 
         # Busy times/percentages for each computer
         print("\nBUSY TIME FOR EACH COMPUTER")

--- a/project1/src/simulator.py
+++ b/project1/src/simulator.py
@@ -87,7 +87,6 @@ class Simulator:
         self.total_runs = 0  # number of completed runs
         self.clock = 0.0  # current simulation timestamp
         self.joint_work_start_time = -1.0  # timestamp for start time of joint work
-        self.joint_work_time = 0.0  # counter for joint work time
 
         self.event_queue = []  # min-heap of pending events
         self.computers = []  # computer entities indexed by ID
@@ -117,8 +116,7 @@ class Simulator:
         self.event_queue.clear()  # remove any pending events
         self.computers.clear()  # reset computer container
         self.stats_collector.clear_iteration_records()  # clear stats for new run
-        self.joint_work_start_time = -1
-        self.joint_work_time = 0.0
+        self.joint_work_start_time = -1  # reset mark for start of joint work
 
         # fresh computer instances for this run
         self.master_computer = MasterComputer()
@@ -364,7 +362,7 @@ class Simulator:
             lazy_computer=self.lazy_computer,
             sim_number=self.total_runs,
             speed=self.speed_mode,
-            joint_work_time=self.joint_work_time
+            joint_work_time=self.stats_collector.joint_work_time
         )
 
         # Verification to mark end of simulations
@@ -531,8 +529,7 @@ class Simulator:
         # If the 3 computers were working together, update the joint work time
         # The time is updated locally and in the stats collector
         if self.joint_work_start_time != -1:
-            addend_joint_work = (self.clock - self.joint_work_start_time)
-            self.joint_work_time += addend_joint_work
+            addend_joint_work = self.clock - self.joint_work_start_time
             self.stats_collector.add_joint_work_time(addend_joint_work)
             self.joint_work_start_time = -1
 


### PR DESCRIPTION
**Summary**
Some fixes and changes were applied in the `Simulator` and `Logger` classes.

**Simulator Changes**

- The duration for each run of the simulation (and the total time of the runs) is now saved in a file called "durations.txt".
- In show_collected_stats(), the unit for the efficiency coefficients has been removed.
- In handle_processing_end(), computers keep working if their queue of messages is not empty; this solves the problem in which computers didn't continue working even if their queue had messages.
- Closes #30 

**Logger Changes**

- Instead of showing the total processing time of the 3 computers during each event, the current joint work time of the simulation is shown.
- Closes #28 
